### PR TITLE
fix inconsistent thumbnail sizes - ref #1

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -16,6 +16,13 @@
 
       .thumbnail {
         width: 100%;
+        height: calc(25vw * 0.56);
+        object-fit: cover;
+      }
+      @media all and (max-width: 768px) {
+        .thumbnail {
+          height: calc(100vw * 0.56);
+        }
       }
 
       .video-container {


### PR DESCRIPTION
Use css object-fit to contain the image. And css calc to determine new the aspect ratio height of the thumbnails, where the assumption is that the width of each thumbnail is approximate 25% of the view. Added additional media-query at 768px for the single column view.